### PR TITLE
Switches to the official Highlight.js module

### DIFF
--- a/journo.litcoffee
+++ b/journo.litcoffee
@@ -194,12 +194,14 @@ We syntax-highlight blocks of code with the nifty **highlight** package that
 includes heuristics for auto-language detection, so you don't have to specify
 what you're coding in.
 
-    {Highlight} = require 'highlight'
+    highlight = require 'highlight.js'
 
     marked.setOptions
       highlight: (code, lang) ->
-        Highlight code
-
+        if highlight.LANGUAGES[lang]?
+          highlight.highlight(lang, code, true).value
+        else
+          highlight.highlightAuto(code).value
 
 Publish a Feed
 --------------

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "underscore": ">= 1.4.3",
     "marked": ">= 0.2.6",
     "mime": ">= 1.2.7",
-    "highlight": ">= 0.2.3",
+    "highlight.js": ">= 7.3.0",
     "rss": ">= 0.0.4"
   },
   "devDependencies": {},


### PR DESCRIPTION
The highlight module being used previously is a 
little quirky out of the box (for me, it was only
loading PHP by default and actually didn't have 
CoffeeScript present at all). 

Additionally, even with the official module, my
CoffeeScript is usually detected as if it were 
Perl (I'm not sure what this says about me), so
I wanted to continue supporting named code blocks
(e.g. ``` coffeescript)
