### PR TITLE
Creating the "public" folder in journo init

### DIFF
--- a/journo.js
+++ b/journo.js
@@ -174,7 +174,7 @@
   Journo.init = function() {
     var bootstrap, here;
     here = fs.realpathSync('.');
-    if (fs.existsSync('posts')) {
+    if (fs.existsSync('posts') || fs.existsSync('public')) {
       fatal("A blog already exists in " + here);
     }
     bootstrap = path.join(__dirname, 'bootstrap/*');
@@ -182,6 +182,7 @@
       if (err) {
         throw err;
       }
+      fs.mkdirSync("public");
       return console.log("Initialized new blog in " + here);
     });
   };

--- a/journo.litcoffee
+++ b/journo.litcoffee
@@ -251,15 +251,16 @@ Quickly Bootstrap a New Blog
 ----------------------------
 
 We **init** a new blog into the current directory by copying over the contents
-of a basic `bootstrap` folder.
+of a basic `bootstrap` folder and creating a `public` folder for static content.
 
     Journo.init = ->
       here = fs.realpathSync '.'
-      if fs.existsSync 'posts'
+      if fs.existsSync('posts') or fs.existsSync('public')
         fatal "A blog already exists in #{here}"
       bootstrap = path.join(__dirname, 'bootstrap/*')
       exec "rsync -vur --delete #{bootstrap} .", (err, stdout, stderr) ->
         throw err if err
+        fs.mkdirSync "public"
         console.log "Initialized new blog in #{here}"
 
 


### PR DESCRIPTION
This would create the `./public` folder to the `Journo.init` function. It makes starting a new blog a little easier.
